### PR TITLE
Added rows prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ props: {
    * The 'name' attribute that will be applied to the end textarea.
    */
   name: String,
+  
+  /**
+   * The 'rows' attribute that will be applied to the end textarea. Controlls initial height of the element.
+   */
+  rows: String,
 }
 ```
                         

--- a/src/TextareaAutogrow.vue
+++ b/src/TextareaAutogrow.vue
@@ -1,6 +1,7 @@
 <template>
   <textarea
       :value="value"
+      :rows="rows"
       @input="$emit('input', $event.target.value)"
 
       @keydown="setAutoHeight"
@@ -33,6 +34,11 @@
        * The 'name' attribute that will be applied to the end textarea.
        */
       name: String,
+      
+      /**
+       * The 'rows' attribute that will be applied to the end textarea.
+       */
+      rows: String,
     },
 
     data() {


### PR DESCRIPTION
Rows prop defines initial height of the textarea element on first render. The default is 2 rows, but we might need more or less rows :) 

Source & readme updated